### PR TITLE
Fix reports for empty datetime fields

### DIFF
--- a/R/reports.R
+++ b/R/reports.R
@@ -170,6 +170,7 @@ plot_timeseries_static <- function(agg_field,
 
   if (is_ft_datetime(agg_field$field_type) &&
       all(is.na(plot_values[[agg_fun_colname]]))) {
+    # Avoid POSIXct scale break errors when the plotted range is all missing.
     plot_values[[agg_fun_colname]] <- as.numeric(plot_values[[agg_fun_colname]])
   }
 

--- a/R/reports.R
+++ b/R/reports.R
@@ -165,10 +165,18 @@ report_data <- function(source_data,
 plot_timeseries_static <- function(agg_field,
                                    agg_fun_colname) {
   timepoint_aggcol_name <- names(agg_field$values)[1]
+  plot_values <-
+    agg_field$values[, c(timepoint_aggcol_name, agg_fun_colname), with = FALSE]
+
+  if (is_ft_datetime(agg_field$field_type) &&
+      all(is.na(plot_values[[agg_fun_colname]]))) {
+    plot_values[[agg_fun_colname]] <- as.numeric(plot_values[[agg_fun_colname]])
+  }
+
   # set up universal plot characteristics
   g <-
     ggplot2::ggplot(
-      agg_field$values[, c(timepoint_aggcol_name, agg_fun_colname), with = FALSE],
+      plot_values,
       ggplot2::aes(.data[[timepoint_aggcol_name]], .data[[agg_fun_colname]])
     ) +
     ggplot2::scale_x_date(

--- a/tests/testthat/_snaps/source_data.md
+++ b/tests/testthat/_snaps/source_data.md
@@ -34,6 +34,7 @@
       27:   col_numeric_dirty               expected a double, but got '`12.11''
       28: col_numeric_missing          expected a double, but got 'not a number'
                    field_name                                            message
+                       <char>                                             <char>
           instances
               <int>
        1:         6
@@ -65,6 +66,7 @@
       27:         1
       28:         4
           instances
+              <int>
 
 # source_data object prints to console ok
 
@@ -172,6 +174,7 @@
     27:   col_numeric_dirty               expected a double, but got '`12.11''
     28: col_numeric_missing          expected a double, but got 'not a number'
                  field_name                                            message
+                     <char>                                             <char>
         instances
             <int>
      1:         6
@@ -203,6 +206,7 @@
     27:         1
     28:         4
         instances
+            <int>
 
 # source_data object prints to console ok when there is a strata field
 

--- a/tests/testthat/test-reports.R
+++ b/tests/testthat/test-reports.R
@@ -142,6 +142,51 @@ test_that("plots still work when all values are missing", {
   )
 })
 
+test_that("report works when all datetime values are missing", {
+  df <-
+    data.table::data.table(
+      "col_timepoint" = paste0("2022-01-", seq(10, 12)),
+      "col_datetime_missing" = ""
+    )
+  source_data <-
+    prepare_data(
+      df,
+      field_types = field_types(
+        col_timepoint = ft_timepoint(),
+        col_datetime_missing = ft_datetime()
+      ),
+      dataset_description = "blankdatetimetest",
+      override_column_names = FALSE,
+      na = c(""),
+      show_progress = FALSE
+    )
+  aggregated_data <-
+    aggregate_data(source_data,
+      aggregation_timeunit = "day",
+      show_progress = FALSE
+    )
+
+  p <-
+    plot_timeseries_static(
+      agg_field = aggregated_data$aggregated_fields$col_datetime_missing,
+      agg_fun_colname = "min"
+    )
+  expect_error(print(p), NA)
+
+  reportpath <-
+    report_data(
+      source_data,
+      aggregated_data,
+      report_title = "Blank Datetime Test",
+      save_directory = tempdir(),
+      save_filename = "daiquiri_blank_datetime_testthatreport",
+      show_progress = FALSE
+    )
+
+  expect_type(reportpath, "character")
+  expect_true(file.remove(reportpath))
+})
+
 
 test_that("plot_timeseries_static() looks how it should", {
   df <- read_data(test_path("testdata", "completetestset.csv"))
@@ -421,4 +466,3 @@ test_that("plot_stratified_combo_static() looks how it should", {
     fig = p
   )
 })
-


### PR DESCRIPTION
## Summary
Handle report plots for datetime fields whose values are all missing.

## Thanks to maintainers
Thanks for maintaining daiquiri and for keeping the report-generation path easy to test locally.

## Issue or motivation
Closes #23. A report can fail when an `ft_datetime()` field has no valid values, because the individual-field section still tries to print the empty datetime min/max plot.

## Root cause
`plot_timeseries_static()` already skips adding points and y-axis limits when all values are `NA`, which works for numeric fields. For datetime aggregation columns, however, the plot data still carries an all-`NA` POSIXct y value. When ggplot builds the plot, the default POSIX scale tries to calculate breaks from non-finite limits and errors before the blank plot can render.

## Change
When the selected aggregation column belongs to a datetime field and all values are missing, convert that plotted y column to numeric `NA` before constructing the ggplot object. This keeps the existing blank-plot behavior but avoids the POSIX break calculation on all-missing datetime values.

I also added a regression test that builds and renders a small report with an all-missing `ft_datetime()` field.

## Tests
- Reproduced the issue locally with an all-missing `ft_datetime()` field, then confirmed the plot and report render after the fix.
- `Rscript -e 'pkgload::load_all(".", quiet = TRUE); testthat::test_file("tests/testthat/test-reports.R")'`
- `git diff --check`
- `R CMD build .`
- `R CMD check --no-manual daiquiri_1.2.1.tar.gz`

## Scope
This does not change aggregation results, datetime parsing, report layout, or plots that contain at least one non-missing datetime value. It only handles the all-missing datetime plotting case.
